### PR TITLE
remove extra line in element (issue #4)

### DIFF
--- a/prism-js.html
+++ b/prism-js.html
@@ -1,4 +1,3 @@
-
 <!-- include polymer -->
 <link rel="import" href="components/polymer/polymer.html">
 
@@ -35,7 +34,7 @@
 	</style>
 	<pre class="{{ {'line-numbers': linenumbers} | tokenList }}">
 		<code id="codeviewer" class="language-{{language}}"></code>
-	</pre>
+</pre>
 </template>
   <script>
     (function() {


### PR DESCRIPTION
Removing the indentation on line 38 in prism-js.html fixes the white space issue. Not sure if this is an acceptable fix as it requires less elegant markup in the template. I tried to approach the problem with regular expressions, but did not find any success.
