### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "tests"
   ],
   "dependencies": {
-    "prismjs": "*",
+    "prism": "*",
     "he": "~0.3.6",
     "polymer": "Polymer/polymer#~0.3.5",
     "core-input": "Polymer/core-input#~0.3.5"


### PR DESCRIPTION
Primsjs changed the name to prism, on bower install you got this error: 

ENOTFOUND Package prismjs not found
